### PR TITLE
Fix fullName, identityToken and authorizationCode return values

### DIFF
--- a/ios/AppleAuthentication.m
+++ b/ios/AppleAuthentication.m
@@ -79,8 +79,24 @@ RCT_EXPORT_METHOD(requestAsync:(NSDictionary *)options
 - (void)authorizationController:(ASAuthorizationController *)controller
    didCompleteWithAuthorization:(ASAuthorization *)authorization {
   ASAuthorizationAppleIDCredential* credential = authorization.credential;
+  NSMutableDictionary *fullName;
+  if ([credential valueForKey:@"fullName"] != nil) {
+    fullName = [[credential.fullName dictionaryWithValuesForKeys:@[
+        @"namePrefix",
+        @"givenName",
+        @"middleName",
+        @"familyName",
+        @"nameSuffix",
+        @"nickname",
+    ]] mutableCopy];
+    [fullName enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+      if (obj == nil) {
+        fullName[key] = [NSNull null];
+      }
+    }];
+  }
   NSDictionary* user = @{
-                         @"fullName": RCTNullIfNil(credential.fullName),
+                         @"fullName": RCTNullIfNil(fullName),
                          @"email": RCTNullIfNil(credential.email),
                          @"user": credential.user,
                          @"authorizedScopes": credential.authorizedScopes,

--- a/ios/AppleAuthentication.m
+++ b/ios/AppleAuthentication.m
@@ -79,6 +79,20 @@ RCT_EXPORT_METHOD(requestAsync:(NSDictionary *)options
 - (void)authorizationController:(ASAuthorizationController *)controller
    didCompleteWithAuthorization:(ASAuthorization *)authorization {
   ASAuthorizationAppleIDCredential* credential = authorization.credential;
+  NSString *identityToken;
+  if ([credential valueForKey:@"identityToken"] != nil) {
+    identityToken = [
+        [NSString alloc] initWithData:[credential valueForKey:@"identityToken"] encoding:NSUTF8StringEncoding
+    ];
+  }
+
+  NSString *authorizationCode;
+  if ([credential valueForKey:@"authorizationCode"] != nil) {
+    authorizationCode = [
+        [NSString alloc] initWithData:[credential valueForKey:@"authorizationCode"] encoding:NSUTF8StringEncoding
+    ];
+  }
+
   NSMutableDictionary *fullName;
   if ([credential valueForKey:@"fullName"] != nil) {
     fullName = [[credential.fullName dictionaryWithValuesForKeys:@[
@@ -102,8 +116,8 @@ RCT_EXPORT_METHOD(requestAsync:(NSDictionary *)options
                          @"authorizedScopes": credential.authorizedScopes,
                          @"realUserStatus": @(credential.realUserStatus),
                          @"state": RCTNullIfNil(credential.state),
-                         @"authorizationCode": RCTNullIfNil(credential.authorizationCode),
-                         @"identityToken": RCTNullIfNil(credential.identityToken)
+                         @"authorizationCode": RCTNullIfNil(authorizationCode),
+                         @"identityToken": RCTNullIfNil(identityToken)
                          };
   _promiseResolve(user);
 }


### PR DESCRIPTION
fullName was returning null on first sign up. Now, fullName is an object of which givenName and familyName will give you the fullName. Other fields of the object are usually null (Didn't come across a case where it isn't. Maybe with different scopes it could be the case.)

P.S. Should probably add a step in installation instructing people to copy RNCSignInWithAppleButton.h, RNCSignInWithAppleButton.m and RNCSignInWithAppleButtonManager.m into the project directory and into compile sources. Also, a usage towards a custom button would help too!